### PR TITLE
fix/make file upload directly client -> supabase

### DIFF
--- a/dataset_explorer/app/api/upload-finish/route.ts
+++ b/dataset_explorer/app/api/upload-finish/route.ts
@@ -1,0 +1,40 @@
+// app/api/upload-finish/route.ts
+
+import { supabaseServer } from "@lib/supabaseServer";
+
+export async function POST(req: Request) {
+  const { datasetId, storagePath, isZip } = await req.json();
+
+  if (isZip) {
+    return Response.json({
+      success: true,
+      isZip: true,
+      zipPath: storagePath,
+    });
+  }
+
+  const { data, error } = await supabaseServer
+    .from("images")
+    .insert({
+      dataset_id: datasetId,
+      storage_path: storagePath,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    return Response.json({ success: false, error: error.message }, { status: 500 });
+  }
+
+  return Response.json({
+    success: true,
+    isZip: false,
+    thumbnails: [
+      {
+        id: data.id,
+        url: "",
+        storage_path: storagePath,
+      },
+    ],
+  });
+}

--- a/dataset_explorer/app/api/upload-url/route.ts
+++ b/dataset_explorer/app/api/upload-url/route.ts
@@ -1,0 +1,28 @@
+
+import { supabaseServer } from "@lib/supabaseServer";
+
+export async function POST(req: Request) {
+  const { fileName, fileType, userId, datasetName } = await req.json();
+
+  if (!fileName || !fileType || !userId || !datasetName) {
+    return Response.json(
+      { error: "Missing fields" },
+      { status: 400 }
+    );
+  }
+
+  const storagePath = `${userId}/${datasetName}/${fileName}`;
+  
+  const { data, error } = await supabaseServer.storage
+    .from("datasets")
+    .createSignedUploadUrl(storagePath);
+
+  if (error) {
+    return Response.json({ error: error.message }, { status: 500 });
+  }
+
+  return Response.json({
+    uploadUrl: data.signedUrl,
+    storagePath,
+  });
+}

--- a/dataset_explorer/hooks/useUpdateImages.ts
+++ b/dataset_explorer/hooks/useUpdateImages.ts
@@ -49,110 +49,93 @@ export function useUpdateImages(handlers: ImageOperationsHandlers = {}) {
   };
 
   const handleUploadFiles = async (
-    files: FileList | null,
-    datasetId: string,
-    datasetName: string,
-    userId: string,
-    onOptimisticAdd: (thumbnails: ImageThumbnail[]) => void,
-  ) => {
-    if (!files || !userId || !datasetId) return;
+  files: FileList | null,
+  datasetId: string,
+  datasetName: string,
+  userId: string,
+  onOptimisticAdd: (thumbnails: ImageThumbnail[]) => void,
+) => {
+  if (!files || files.length === 0 || !userId || !datasetId) return;
 
-    setUploading(true);
-    setMessage(null);
+  setUploading(true);
+  setMessage(null);
 
-    try {
-      const fd = new FormData();
-      Array.from(files).forEach((f) => fd.append("files", f));
+  try {
+    const file = files[0]; // only one file is supported currently (either single image or zip) TODO - improve this in future to support up to 15 files upload without zip
+    setUploadProgress(0);
 
-      fd.append("datasetId", datasetId);
-      fd.append("datasetName", datasetName);
-      fd.append("userId", userId);
+    const result = await uploadWithProgress({
+      file,
+      datasetId,
+      datasetName,
+      userId,
+      onProgress: setUploadProgress,
+    });
 
-      setUploadProgress(0);
+    if (!result.success) {
+      setMessage({ message: `Upload error: ${result.error}`, type: "error" });
+      return;
+    }
+    if (result.isZip) {
+      setProcessingZip(true);
 
-      const json = await uploadWithProgress({
-        url: "/api/upload",
-        formData: fd,
-        onProgress: setUploadProgress,
-      });
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1/process-zip`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY}`,
+            apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+          },
+          body: JSON.stringify({
+            datasetId,
+            datasetName,
+            userId,
+            zipPath: result.zipPath,
+          }),
+        },
+      );
 
-      if (!json.success) {
+      const fx = await res.json();
+      setProcessingZip(false);
+
+      if (!fx.success) {
         setMessage({
-          message: `Upload error: ${json.error}`,
+          message: "Processing error: " + fx.error,
           type: "error",
         });
         return;
       }
 
-      setMessage({
-        message: "Upload complete",
-        type: "success",
-      });
-
-      if (json.isZip) {
-        setProcessingZip(true);
-
-        const res = await fetch(
-          `${process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1/process-zip`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: `Bearer ${process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY}`,
-              apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-            },
-            body: JSON.stringify({
-              datasetId,
-              datasetName,
-              userId,
-              zipPath: json.zipPath,
-            }),
-          },
-        );
-
-        const fx = await res.json();
-        setProcessingZip(false);
-
-        if (!fx.success) {
-          setMessage({
-            message: "Processing error: " + fx.error,
-            type: "error",
-          });
-          return;
-        }
-
-        handlers.onUploadComplete?.();
-        return;
-      }
-
-      if (!json.isZip) {
-        const newThumbnails = await Promise.all(
-          json.thumbnails.map(async (t) => {
-            const { data } = await supabase.storage
-              .from("datasets")
-              .createSignedUrl(t.storage_path, 3600);
-
-            return {
-              ...t,
-              url: data?.signedUrl ?? t.url ?? "",
-            };
-          }),
-        );
-
-        onOptimisticAdd(newThumbnails);
-      } else {
-        handlers.onUploadComplete?.();
-      }
-    } catch (err: any) {
-      console.error(err);
-      setMessage({
-        message: "Upload error: " + (err?.message ?? String(err)),
-        type: "error",
-      });
-    } finally {
-      setUploading(false);
+      setMessage({ message: "Upload complete", type: "success" });
+      handlers.onUploadComplete?.();
+      return;
     }
-  };
+    const thumbWithUrl = await Promise.all(
+      result.thumbnails.map(async (t: ImageThumbnail) => {
+        const { data } = await supabase.storage
+          .from("datasets")
+          .createSignedUrl(t.storage_path, 3600);
+
+        return { ...t, url: data?.signedUrl ?? "" };
+      }),
+    );
+
+    onOptimisticAdd(thumbWithUrl);
+
+    setMessage({ message: "Upload complete", type: "success" });
+    handlers.onUploadComplete?.();
+  } catch (err: any) {
+    console.error(err);
+    setMessage({
+      message: "Upload error: " + (err?.message ?? String(err)),
+      type: "error",
+    });
+  } finally {
+    setUploading(false);
+  }
+};
 
   return {
     uploading,


### PR DESCRIPTION
This PR deprecates the old upload endpoint which acted as a middle man for uploading files to supabase bucket. Instead, we introduce two new endpoints: 

- upload-url - creates signed url (no file data passed over payload)
- upload-finish - either inserts single image in DB or returns zip storage path (as edge function processes zip and uploads images into table)

This should bypass next.js payload limits in production 