### PR TITLE
improvement/create dataset context with logic from useDatasets

### DIFF
--- a/dataset_explorer/app/layout.tsx
+++ b/dataset_explorer/app/layout.tsx
@@ -4,6 +4,7 @@ import { AuthProvider } from "@components/AuthProvider";
 import { ReactQueryProvider } from "@lib/tanstackQueryProvider";
 import { Toaster } from "sonner";
 import { NetworkIndicator } from "@components/NetworkIndicator";
+import { DatasetProvider } from "@contexts/DatasetContext";
 
 export const metadata: Metadata = {
   title: "DataPilot",
@@ -19,12 +20,15 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <ReactQueryProvider>
-          <AuthProvider>{children}</AuthProvider>
-          <Toaster position="top-right" richColors closeButton />
-          <NetworkIndicator/>
-        </ReactQueryProvider>
-        
+        <DatasetProvider>
+          <ReactQueryProvider>
+            <AuthProvider>
+              {children}
+            </AuthProvider>
+            <Toaster position="top-right" richColors closeButton />
+            <NetworkIndicator/>
+          </ReactQueryProvider>
+        </DatasetProvider>
       </body>
     </html>
   );

--- a/dataset_explorer/contexts/DatasetContext.tsx
+++ b/dataset_explorer/contexts/DatasetContext.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  ReactNode,
+} from "react";
+import {
+  fetchDatasetsAction,
+  createDatasetAction,
+} from "@lib/actions/dataset";
+
+import type { Dataset, OperationMessage } from "@lib/types";
+
+export type DatasetContextValue = {
+  datasets: Dataset[];
+  counts: Record<string, number>;
+  selected: string;
+  setSelected: (id: string) => void;
+  message: OperationMessage;
+  setMessage: (msg: OperationMessage) => void;
+  loadDatasets: (userId: string) => Promise<void>;
+  createDataset: (name: string, userId: string) => Promise<void>;
+  isPending: boolean;
+};
+
+const DatasetContext = createContext<DatasetContextValue | null>(null);
+
+export function DatasetProvider({ children }: { children: ReactNode }) {
+  const [datasets, setDatasets] = useState<Dataset[]>([]);
+  const [counts, setCounts] = useState<Record<string, number>>({});
+  const [selected, setSelected] = useState<string>("");
+  const [message, setMessage] = useState<OperationMessage>(null);
+  const [isPending, setIsPending] = useState<boolean>(false);
+
+  const loadDatasets = async (userId: string): Promise<void> => {
+    if (!userId) return;
+
+    setIsPending(true);
+    const result = await fetchDatasetsAction(userId);
+    setIsPending(false);
+
+    if (result.error) {
+      setMessage({ type: "error", message: result.error });
+      setDatasets([]);
+      setCounts({});
+      return;
+    }
+
+    setDatasets(result.datasets);
+    setCounts(result.counts);
+
+    if (!selected && result.datasets.length > 0) {
+      const saved = localStorage.getItem("selectedDatasetId");
+
+      if (saved && result.datasets.some((d) => d.id === saved)) {
+        setSelected(saved);
+      } else {
+        setSelected(result.datasets[0].id);
+      }
+    }
+  };
+
+  const createDataset = async (
+    name: string,
+    userId: string,
+  ): Promise<void> => {
+    if (!name || !userId) return;
+
+    const result = await createDatasetAction(name, userId);
+
+    if (result.error) {
+      setMessage({ type: "error", message: result.error });
+      return;
+    }
+
+    setMessage({ type: "success", message: "Dataset created" });
+
+    setSelected(result.dataset.id);
+    await loadDatasets(userId);
+  };
+
+  useEffect(() => {
+    if (selected) {
+      localStorage.setItem("selectedDatasetId", selected);
+    }
+  }, [selected]);
+
+  const value: DatasetContextValue = useMemo(
+    () => ({
+      datasets,
+      counts,
+      selected,
+      setSelected,
+      message,
+      setMessage,
+      loadDatasets,
+      createDataset,
+      isPending,
+    }),
+    [datasets, counts, selected, message, isPending],
+  );
+
+  return (
+    <DatasetContext.Provider value={value}>
+      {children}
+    </DatasetContext.Provider>
+  );
+}
+
+export function useDataset(): DatasetContextValue {
+  const ctx = useContext(DatasetContext);
+
+  if (!ctx) {
+    throw new Error("useDataset must be used within a DatasetProvider");
+  }
+
+  return ctx;
+}

--- a/dataset_explorer/tsconfig.json
+++ b/dataset_explorer/tsconfig.json
@@ -23,7 +23,8 @@
       "@lib/*": ["lib/*"],
       "@styles/*": ["styles/*"],
       "@pages/*": ["pages/*"],
-      "@hooks/*": ["hooks/*"]
+      "@hooks/*": ["hooks/*"],
+      "@contexts/*": ["contexts/*"]
     }
   },
   "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],


### PR DESCRIPTION
First in a series of PR's to improve dataset selection UX across the app. Globalizing dataset selection and loading logic will reduce duplication across the pages and keep dataset state in sync