### PR TITLE
Improvement/UX- use skeleton for dataset image grid loading

### DIFF
--- a/dataset_explorer/app/datasets/DatasetsContent.tsx
+++ b/dataset_explorer/app/datasets/DatasetsContent.tsx
@@ -147,10 +147,10 @@ export function DatasetsContent({
     });
   };
   const handlePageSizeChange = (size: number) => {
-    setImagesPage(1); 
-    setImagesPerPage(size)
-    cache.invalidate(selected)
-};
+    setImagesPage(1);
+    setImagesPerPage(size);
+    cache.invalidate(selected);
+  };
 
   const handleCreateDataset = () => {
     if (!newName || !user) return;

--- a/dataset_explorer/app/datasets/sections/DatasetImagesCard.tsx
+++ b/dataset_explorer/app/datasets/sections/DatasetImagesCard.tsx
@@ -15,14 +15,17 @@ export function DatasetImagesCard({
   selected,
   imagesLoading,
   handleDeleteImages,
-  onPageSizeChange
+  onPageSizeChange,
 }: DatasetImagesCardProps) {
   return (
     <div className="bg-[#121212] border border-[#1F1F1F] rounded-lg p-6">
       <h3 className="text-xl text-white mb-4">Images in dataset</h3>
 
       {imagesLoading ? (
-        <DatasetImagesSkeleton text="Loading your dataset..." perPage={imagesPerPage}/>
+        <DatasetImagesSkeleton
+          text="Loading your dataset..."
+          perPage={imagesPerPage}
+        />
       ) : !selected ? (
         <div className="text-sm text-[#6B6B6B]">
           Select a dataset to view images.

--- a/dataset_explorer/components/DatasetsPage/DatasetImageGrid.tsx
+++ b/dataset_explorer/components/DatasetsPage/DatasetImageGrid.tsx
@@ -29,7 +29,7 @@ type Props = {
   onNextPage: () => void;
 };
 
-const PAGE_SIZE_OPTIONS = [12, 20, 50]
+const PAGE_SIZE_OPTIONS = [12, 20, 50];
 
 function DatasetImageGrid({
   thumbnails,

--- a/dataset_explorer/components/DatasetsPage/DatasetImagesSkeleton.tsx
+++ b/dataset_explorer/components/DatasetsPage/DatasetImagesSkeleton.tsx
@@ -5,7 +5,7 @@ import { Skeleton } from "@components/ui/skeleton";
 export interface DatasetImagesSkeletonProps {
   text?: string;
   perPage?: number;
-};
+}
 
 export function DatasetImagesSkeleton({
   text = "Loading your dataset...",

--- a/dataset_explorer/lib/actions/dataset.ts
+++ b/dataset_explorer/lib/actions/dataset.ts
@@ -78,10 +78,9 @@ export async function fetchImagesForDatasetAction(
     }
 
     const paths = data.map((img) => img.storage_path);
-    const { data: signedURLs, error: signError } =
-      await supabaseServer.storage
-        .from("datasets")
-        .createSignedUrls(paths, 3600);
+    const { data: signedURLs, error: signError } = await supabaseServer.storage
+      .from("datasets")
+      .createSignedUrls(paths, 3600);
 
     if (signError) throw signError;
     const thumbs: ImageThumbnail[] = data.map((img, i) => ({
@@ -91,7 +90,6 @@ export async function fetchImagesForDatasetAction(
     }));
 
     return { thumbnails: thumbs, total: count ?? 0 };
-
   } catch (err: any) {
     return { thumbnails: [], total: 0, error: err?.message ?? String(err) };
   }


### PR DESCRIPTION
This PR changes dataset image grid to use a dynamic skeleton based on page size for cleaner UX/less page shift on load complete