### PR TITLE
Refactor/move unzipping client side

### DIFF
--- a/dataset_explorer/app/api/bulk-insert/route.ts
+++ b/dataset_explorer/app/api/bulk-insert/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { supabaseServer } from "@lib/supabaseServer";
+
+const BATCH_SIZE = 2000;
+
+export async function POST(req: Request) {
+  try {
+    const { datasetId, storagePaths } = await req.json();
+
+    if (!datasetId || !Array.isArray(storagePaths)) {
+      return NextResponse.json(
+        { success: false, error: "Invalid payload" },
+        { status: 400 }
+      );
+    }
+
+    const insertedIds: string[] = [];
+
+    // Insert in batches to avoid DB size limits
+    for (let i = 0; i < storagePaths.length; i += BATCH_SIZE) {
+      const batch = storagePaths.slice(i, i + BATCH_SIZE).map((path) => ({
+        dataset_id: datasetId,
+        storage_path: path,
+      }));
+
+      const { data, error } = await supabaseServer
+        .from("images")
+        .insert(batch)
+        .select("id"); // return primary keys
+
+      if (error) {
+        console.error("Bulk insert error:", error);
+        return NextResponse.json(
+          { success: false, error: error.message },
+          { status: 500 }
+        );
+      }
+
+      insertedIds.push(...data.map((d:any) => d.id));
+    }
+
+    return NextResponse.json({
+      success: true,
+      count: insertedIds.length,
+      insertedIds,
+    });
+  } catch (err: any) {
+    console.error("Bulk insert route failed:", err);
+    return NextResponse.json(
+      {
+        success: false,
+        error: err?.message || "Unknown error",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/dataset_explorer/app/api/bulk-insert/route.ts
+++ b/dataset_explorer/app/api/bulk-insert/route.ts
@@ -10,7 +10,7 @@ export async function POST(req: Request) {
     if (!datasetId || !Array.isArray(storagePaths)) {
       return NextResponse.json(
         { success: false, error: "Invalid payload" },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
@@ -25,17 +25,17 @@ export async function POST(req: Request) {
       const { data, error } = await supabaseServer
         .from("images")
         .insert(batch)
-        .select("id"); 
+        .select("id");
 
       if (error) {
         console.error("Bulk insert error:", error);
         return NextResponse.json(
           { success: false, error: error.message },
-          { status: 500 }
+          { status: 500 },
         );
       }
 
-      insertedIds.push(...data.map((d:any) => d.id));
+      insertedIds.push(...data.map((d: any) => d.id));
     }
 
     return NextResponse.json({
@@ -50,7 +50,7 @@ export async function POST(req: Request) {
         success: false,
         error: err?.message || "Unknown error",
       },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/dataset_explorer/app/api/bulk-insert/route.ts
+++ b/dataset_explorer/app/api/bulk-insert/route.ts
@@ -16,7 +16,6 @@ export async function POST(req: Request) {
 
     const insertedIds: string[] = [];
 
-    // Insert in batches to avoid DB size limits
     for (let i = 0; i < storagePaths.length; i += BATCH_SIZE) {
       const batch = storagePaths.slice(i, i + BATCH_SIZE).map((path) => ({
         dataset_id: datasetId,
@@ -26,7 +25,7 @@ export async function POST(req: Request) {
       const { data, error } = await supabaseServer
         .from("images")
         .insert(batch)
-        .select("id"); // return primary keys
+        .select("id"); 
 
       if (error) {
         console.error("Bulk insert error:", error);

--- a/dataset_explorer/components/General/ImageViewer/index.tsx
+++ b/dataset_explorer/components/General/ImageViewer/index.tsx
@@ -71,18 +71,12 @@ export function ImageViewer({
     isValidFrame,
   } = useSelectFrame(frameNumber, totalFrames, onGoToFrame);
 
-  
   useEffect(() => {
     // Sync displayed number when frame changes externally
     setFrameInput(frameNumber.toString());
   }, [frameNumber]);
 
-  useAutoplayFrames(
-    isPlaying,
-    500, 
-    onNextFrame,
-    setDrawingDisabled,
-  );
+  useAutoplayFrames(isPlaying, 500, onNextFrame, setDrawingDisabled);
 
   return (
     <div className="flex-1 flex flex-col items-center justify-center p-6 gap-4">

--- a/dataset_explorer/hooks/useUpdateImages.ts
+++ b/dataset_explorer/hooks/useUpdateImages.ts
@@ -13,7 +13,7 @@ interface ImageOperationsHandlers {
   pageSize?: number;
 }
 
-const CONCURRENCY = 8;
+const CONCURRENCY = 24;
 
 export function useUpdateImages(options: ImageOperationsHandlers = {}) {
   const [uploading, setUploading] = useState(false);
@@ -28,12 +28,12 @@ export function useUpdateImages(options: ImageOperationsHandlers = {}) {
     storagePaths: string[],
     onOptimisticDelete: () => void,
   ) => {
-    // Mark all as deleting
+    
     setDeletingIds((prev) => [...prev, ...imageIds]);
     setMessage(null);
 
     startTransition(async () => {
-      // Bulk delete — both arrays must match in length + order!
+      
       const result = await deleteImagesAction(imageIds, storagePaths);
 
       if (result.error) {
@@ -50,13 +50,13 @@ export function useUpdateImages(options: ImageOperationsHandlers = {}) {
           type: "success",
         });
 
-        // Remove them from UI now
+        
         onOptimisticDelete();
 
         options.onDeleteComplete?.();
       }
 
-      // Remove all deleted IDs from the deleting state
+      
       setDeletingIds((prev) => prev.filter((id) => !imageIds.includes(id)));
     });
   };
@@ -74,20 +74,18 @@ async function handleUploadFiles(
   const isZip = file.name.toLowerCase().endsWith(".zip");
 
   if (!isZip) {
-    // Let your existing single-file code handle this
     return;
   }
 
   setUploading(true);
   setProcessingZip(true);
 
-  // 1. Unzip
+  
   const entries = await extractImagesFromZip(file);
   const totalFiles = entries.length;
 
   const uploadedPaths: string[] = [];
 
-  // 2. Create processEntry
   const processEntry = createProcessEntry({
     datasetId,
     datasetName,
@@ -99,7 +97,6 @@ async function handleUploadFiles(
     updateProgress: setUploadProgress,
   });
 
-  // 3. Concurrency pool
   const queue = [...entries];
   const workers = Array.from({ length: CONCURRENCY }, async () => {
     while (queue.length > 0) {

--- a/dataset_explorer/hooks/useUpdateImages.ts
+++ b/dataset_explorer/hooks/useUpdateImages.ts
@@ -28,12 +28,10 @@ export function useUpdateImages(options: ImageOperationsHandlers = {}) {
     storagePaths: string[],
     onOptimisticDelete: () => void,
   ) => {
-    
     setDeletingIds((prev) => [...prev, ...imageIds]);
     setMessage(null);
 
     startTransition(async () => {
-      
       const result = await deleteImagesAction(imageIds, storagePaths);
 
       if (result.error) {
@@ -50,104 +48,104 @@ export function useUpdateImages(options: ImageOperationsHandlers = {}) {
           type: "success",
         });
 
-        
         onOptimisticDelete();
 
         options.onDeleteComplete?.();
       }
 
-      
       setDeletingIds((prev) => prev.filter((id) => !imageIds.includes(id)));
     });
   };
 
-async function handleUploadFiles(
-  files: FileList | null,
-  datasetId: string,
-  datasetName: string,
-  userId: string,
-  onOptimisticAdd: (thumbs: ImageThumbnail[]) => void
-) {
-  if (!files || !files.length) return;
+  async function handleUploadFiles(
+    files: FileList | null,
+    datasetId: string,
+    datasetName: string,
+    userId: string,
+    onOptimisticAdd: (thumbs: ImageThumbnail[]) => void,
+  ) {
+    if (!files || !files.length) return;
 
-  const file = files[0];
-  const isZip = file.name.toLowerCase().endsWith(".zip");
+    const file = files[0];
+    const isZip = file.name.toLowerCase().endsWith(".zip");
 
-  if (!isZip) {
-    return;
-  }
-
-  setUploading(true);
-  setProcessingZip(true);
-
-  
-  const entries = await extractImagesFromZip(file);
-  const totalFiles = entries.length;
-
-  const uploadedPaths: string[] = [];
-  const failedUploads: { name: string; blob: Blob; reason?: string }[] = [];
-
-  const processEntry = createProcessEntry({
-    datasetId,
-    datasetName,
-    userId,
-    totalFiles,
-    onFileUploaded: (paths) => {
-      uploadedPaths.push(...paths);
-    },
-    onFileFailed: (entry) => {
-      failedUploads.push(entry);
-    },
-    updateProgress: setUploadProgress,
-  });
-
-  const queue = [...entries];
-  const workers = Array.from({ length: CONCURRENCY }, async () => {
-    while (queue.length > 0) {
-      const entry = queue.shift();
-      if (entry) await processEntry(entry);
+    if (!isZip) {
+      return;
     }
-  });
 
-  await Promise.all(workers);
+    setUploading(true);
+    setProcessingZip(true);
 
-  const dbRes = await fetch("/api/bulk-insert", {
-    method: "POST",
-    body: JSON.stringify({
+    const entries = await extractImagesFromZip(file);
+    const totalFiles = entries.length;
+
+    const uploadedPaths: string[] = [];
+    const failedUploads: { name: string; blob: Blob; reason?: string }[] = [];
+
+    const processEntry = createProcessEntry({
       datasetId,
-      storagePaths: uploadedPaths,
-    }),
-  }).then((r) => r.json());
+      datasetName,
+      userId,
+      totalFiles,
+      onFileUploaded: (paths) => {
+        uploadedPaths.push(...paths);
+      },
+      onFileFailed: (entry) => {
+        failedUploads.push(entry);
+      },
+      updateProgress: setUploadProgress,
+    });
 
-  if (!dbRes.success) {
-    setMessage({ type: "error", message: dbRes.error });
+    const queue = [...entries];
+    const workers = Array.from({ length: CONCURRENCY }, async () => {
+      while (queue.length > 0) {
+        const entry = queue.shift();
+        if (entry) await processEntry(entry);
+      }
+    });
+
+    await Promise.all(workers);
+
+    const dbRes = await fetch("/api/bulk-insert", {
+      method: "POST",
+      body: JSON.stringify({
+        datasetId,
+        storagePaths: uploadedPaths,
+      }),
+    }).then((r) => r.json());
+
+    if (!dbRes.success) {
+      setMessage({ type: "error", message: dbRes.error });
+      setProcessingZip(false);
+      setUploading(false);
+      return;
+    }
+
+    const pageSize = options.pageSize ?? 12;
+    const firstPagePaths = uploadedPaths.slice(0, pageSize);
+    const firstPageIds = dbRes.insertedIds.slice(0, pageSize);
+
+    // sign first page
+    const { data: signed } = await supabase.storage
+      .from("datasets")
+      .createSignedUrls(firstPagePaths, 3600);
+
+    const firstPageThumbs: ImageThumbnail[] = firstPagePaths.map((path, i) => ({
+      id: firstPageIds[i],
+      storage_path: path,
+      url: signed?.[i]?.signedUrl ?? "",
+    }));
+
+    onOptimisticAdd(firstPageThumbs);
+
+    options?.onUploadComplete?.();
     setProcessingZip(false);
     setUploading(false);
-    return;
+    setMessage({
+      type: "success",
+      message: `${uploadedPaths.length} images uploaded`,
+    });
   }
-
-  const pageSize = options.pageSize ?? 12;
-  const firstPagePaths = uploadedPaths.slice(0, pageSize);
-  const firstPageIds = dbRes.insertedIds.slice(0, pageSize);
-
-  // sign first page
-  const { data: signed } = await supabase.storage
-    .from("datasets")
-    .createSignedUrls(firstPagePaths, 3600);
-
-  const firstPageThumbs: ImageThumbnail[] = firstPagePaths.map((path, i) => ({
-    id: firstPageIds[i],
-    storage_path: path,
-    url: signed?.[i]?.signedUrl ?? "",
-  }));
-
-  onOptimisticAdd(firstPageThumbs);
-
-  options?.onUploadComplete?.();
-  setProcessingZip(false);
-  setUploading(false);
-  setMessage({ type: "success", message: `${uploadedPaths.length} images uploaded` });
-}
 
   return {
     uploading,

--- a/dataset_explorer/hooks/useUpdateImages.ts
+++ b/dataset_explorer/hooks/useUpdateImages.ts
@@ -85,6 +85,7 @@ async function handleUploadFiles(
   const totalFiles = entries.length;
 
   const uploadedPaths: string[] = [];
+  const failedUploads: { name: string; blob: Blob; reason?: string }[] = [];
 
   const processEntry = createProcessEntry({
     datasetId,
@@ -93,6 +94,9 @@ async function handleUploadFiles(
     totalFiles,
     onFileUploaded: (paths) => {
       uploadedPaths.push(...paths);
+    },
+    onFileFailed: (entry) => {
+      failedUploads.push(entry);
     },
     updateProgress: setUploadProgress,
   });
@@ -142,7 +146,7 @@ async function handleUploadFiles(
   options?.onUploadComplete?.();
   setProcessingZip(false);
   setUploading(false);
-  setMessage({ type: "success", message: "Upload complete" });
+  setMessage({ type: "success", message: `${uploadedPaths.length} images uploaded` });
 }
 
   return {

--- a/dataset_explorer/lib/processEntry.ts
+++ b/dataset_explorer/lib/processEntry.ts
@@ -1,6 +1,5 @@
 import { supabase } from "./supabaseClient";
 
-
 export function createProcessEntry({
   datasetId,
   datasetName,
@@ -17,7 +16,7 @@ export function createProcessEntry({
   userId: string;
   totalFiles: number;
   onFileUploaded: (paths: string[]) => void;
-  onFileFailed: (entry: { name: string; blob: Blob, reason?: string }) => void;
+  onFileFailed: (entry: { name: string; blob: Blob; reason?: string }) => void;
   updateProgress: (percent: number) => void;
   maxRetries?: number;
   retryDelay?: number;
@@ -30,7 +29,7 @@ export function createProcessEntry({
     while (attempts < maxRetries) {
       const { error } = await supabase.storage
         .from("datasets")
-        .upload(storagePath, blob,  { upsert: true});
+        .upload(storagePath, blob, { upsert: true });
 
       if (!error) {
         return true;
@@ -40,7 +39,7 @@ export function createProcessEntry({
 
       // progressive delay
       await new Promise((res) =>
-        setTimeout(res, retryDelay * Math.pow(2, attempts - 1))
+        setTimeout(res, retryDelay * Math.pow(2, attempts - 1)),
       );
     }
 
@@ -55,7 +54,7 @@ export function createProcessEntry({
     const success = await uploadWithRetry(storagePath, blob);
 
     if (!success) {
-      onFileFailed({...entry, reason: "Upload failed after retries"}); // collect failed uploads for reporting or retrying
+      onFileFailed({ ...entry, reason: "Upload failed after retries" }); // collect failed uploads for reporting or retrying
     } else {
       onFileUploaded([storagePath]);
     }

--- a/dataset_explorer/lib/processEntry.ts
+++ b/dataset_explorer/lib/processEntry.ts
@@ -30,7 +30,7 @@ export function createProcessEntry({
     while (attempts < maxRetries) {
       const { error } = await supabase.storage
         .from("datasets")
-        .upload(storagePath, blob);
+        .upload(storagePath, blob,  { upsert: true});
 
       if (!error) {
         return true;

--- a/dataset_explorer/lib/processEntry.ts
+++ b/dataset_explorer/lib/processEntry.ts
@@ -1,0 +1,46 @@
+// processEntry.ts
+
+import { supabase } from "./supabaseClient";
+import { uploadWithProgress } from "./uploadWithProgress";
+import type { ImageThumbnail } from "@lib/types";
+
+export function createProcessEntry({
+  datasetId,
+  datasetName,
+  userId,
+  onFileUploaded,
+  updateProgress,
+  totalFiles,
+}: {
+  datasetId: string;
+  datasetName: string;
+  userId: string;
+  totalFiles: number;
+  onFileUploaded: (paths: string[]) => void;
+  updateProgress: (percent: number) => void;
+}) {
+  let completed = 0;
+
+  return async function processEntry(entry: { name: string; blob: Blob }) {
+    const { name, blob } = entry;
+
+    const filename = name.split("/").pop()!;
+    const storagePath = `${userId}/${datasetName}/${filename}`;
+
+    // Upload directly to Supabase Storage
+    const { error } = await supabase.storage
+      .from("datasets")
+      .upload(storagePath, blob, { upsert: true });
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    // Pass only storage path
+    onFileUploaded([storagePath]);
+
+    // Progress update
+    completed++;
+    updateProgress(Math.round((completed / totalFiles) * 100));
+  };
+}

--- a/dataset_explorer/lib/processEntry.ts
+++ b/dataset_explorer/lib/processEntry.ts
@@ -1,8 +1,5 @@
-// processEntry.ts
-
 import { supabase } from "./supabaseClient";
-import { uploadWithProgress } from "./uploadWithProgress";
-import type { ImageThumbnail } from "@lib/types";
+
 
 export function createProcessEntry({
   datasetId,
@@ -27,7 +24,6 @@ export function createProcessEntry({
     const filename = name.split("/").pop()!;
     const storagePath = `${userId}/${datasetName}/${filename}`;
 
-    // Upload directly to Supabase Storage
     const { error } = await supabase.storage
       .from("datasets")
       .upload(storagePath, blob, { upsert: true });
@@ -36,7 +32,6 @@ export function createProcessEntry({
       throw new Error(error.message);
     }
 
-    // Pass only storage path
     onFileUploaded([storagePath]);
 
     // Progress update

--- a/dataset_explorer/lib/processEntry.ts
+++ b/dataset_explorer/lib/processEntry.ts
@@ -5,36 +5,61 @@ export function createProcessEntry({
   datasetId,
   datasetName,
   userId,
-  onFileUploaded,
-  updateProgress,
   totalFiles,
+  onFileUploaded,
+  onFileFailed,
+  updateProgress,
+  maxRetries = 3,
+  retryDelay = 500, // ms
 }: {
   datasetId: string;
   datasetName: string;
   userId: string;
   totalFiles: number;
   onFileUploaded: (paths: string[]) => void;
+  onFileFailed: (entry: { name: string; blob: Blob, reason?: string }) => void;
   updateProgress: (percent: number) => void;
+  maxRetries?: number;
+  retryDelay?: number;
 }) {
   let completed = 0;
 
+  async function uploadWithRetry(storagePath: string, blob: Blob) {
+    let attempts = 0;
+
+    while (attempts < maxRetries) {
+      const { error } = await supabase.storage
+        .from("datasets")
+        .upload(storagePath, blob);
+
+      if (!error) {
+        return true;
+      }
+
+      attempts++;
+
+      // progressive delay
+      await new Promise((res) =>
+        setTimeout(res, retryDelay * Math.pow(2, attempts - 1))
+      );
+    }
+
+    return false;
+  }
+
   return async function processEntry(entry: { name: string; blob: Blob }) {
     const { name, blob } = entry;
-
     const filename = name.split("/").pop()!;
     const storagePath = `${userId}/${datasetName}/${filename}`;
 
-    const { error } = await supabase.storage
-      .from("datasets")
-      .upload(storagePath, blob, { upsert: true });
+    const success = await uploadWithRetry(storagePath, blob);
 
-    if (error) {
-      throw new Error(error.message);
+    if (!success) {
+      onFileFailed({...entry, reason: "Upload failed after retries"}); // collect failed uploads for reporting or retrying
+    } else {
+      onFileUploaded([storagePath]);
     }
 
-    onFileUploaded([storagePath]);
-
-    // Progress update
     completed++;
     updateProgress(Math.round((completed / totalFiles) * 100));
   };

--- a/dataset_explorer/lib/uploadWithProgress.ts
+++ b/dataset_explorer/lib/uploadWithProgress.ts
@@ -11,7 +11,6 @@ export async function uploadWithProgress({
   userId: string;
   onProgress?: (percent: number) => void;
 }) {
-  
   const { uploadUrl, storagePath } = await fetch("/api/upload-url", {
     method: "POST",
     body: JSON.stringify({
@@ -45,7 +44,7 @@ export async function uploadWithProgress({
     body: JSON.stringify({
       datasetId,
       storagePath,
-      isZip: false, // TODO: remove this server-side 
+      isZip: false, // TODO: remove this server-side
     }),
   }).then((r) => r.json());
 

--- a/dataset_explorer/lib/uploadWithProgress.ts
+++ b/dataset_explorer/lib/uploadWithProgress.ts
@@ -11,7 +11,7 @@ export async function uploadWithProgress({
   userId: string;
   onProgress?: (percent: number) => void;
 }) {
-  // Request signed URL
+  
   const { uploadUrl, storagePath } = await fetch("/api/upload-url", {
     method: "POST",
     body: JSON.stringify({
@@ -22,7 +22,6 @@ export async function uploadWithProgress({
     }),
   }).then((r) => r.json());
 
-  // Upload to Supabase Storage
   await new Promise<void>((resolve, reject) => {
     const xhr = new XMLHttpRequest();
     xhr.open("PUT", uploadUrl);
@@ -41,19 +40,20 @@ export async function uploadWithProgress({
     xhr.send(file);
   });
 
-  const isZip = file.name.toLowerCase().endsWith(".zip");
-
-  // Finish route stores DB route (if it is a single image) or just returns storage path
   const result = await fetch("/api/upload-finish", {
     method: "POST",
     body: JSON.stringify({
       datasetId,
       storagePath,
-      isZip,
+      isZip: false, // TODO: remove this server-side 
     }),
   }).then((r) => r.json());
 
-  return result as UploadResponse;
+  return result as {
+    success: boolean;
+    error?: string;
+    thumbnails: { id: string; url: string; storage_path: string }[];
+  };
 }
 
 type UploadResponse = {

--- a/dataset_explorer/lib/zipUtils.ts
+++ b/dataset_explorer/lib/zipUtils.ts
@@ -15,12 +15,12 @@ export async function extractImagesFromZip(file: File) {
       !lower.endsWith(".jpeg") &&
       !lower.endsWith(".png") &&
       !lower.endsWith(".webp")
-    ) continue;
+    )
+      continue;
 
-    const mime =
-      lower.endsWith(".png")
-        ? "image/png"
-        : lower.endsWith(".webp")
+    const mime = lower.endsWith(".png")
+      ? "image/png"
+      : lower.endsWith(".webp")
         ? "image/webp"
         : "image/jpeg";
 

--- a/dataset_explorer/lib/zipUtils.ts
+++ b/dataset_explorer/lib/zipUtils.ts
@@ -1,0 +1,34 @@
+import { unzipSync } from "fflate";
+
+export async function extractImagesFromZip(file: File) {
+  const buffer = await file.arrayBuffer();
+  const files = unzipSync(new Uint8Array(buffer));
+
+  const results: { name: string; blob: Blob }[] = [];
+
+  for (const [name, data] of Object.entries(files)) {
+    const arr = data;
+
+    const lower = name.toLowerCase();
+    if (
+      !lower.endsWith(".jpg") &&
+      !lower.endsWith(".jpeg") &&
+      !lower.endsWith(".png") &&
+      !lower.endsWith(".webp")
+    ) continue;
+
+    const mime =
+      lower.endsWith(".png")
+        ? "image/png"
+        : lower.endsWith(".webp")
+        ? "image/webp"
+        : "image/jpeg";
+
+    results.push({
+      name,
+      blob: new Blob([arr as BlobPart], { type: mime }),
+    });
+  }
+
+  return results;
+}

--- a/dataset_explorer/package-lock.json
+++ b/dataset_explorer/package-lock.json
@@ -48,6 +48,7 @@
         "cmdk": "^1.0.0",
         "date-fns": "^3.0.0",
         "embla-carousel-react": "^8.0.0",
+        "fflate": "^0.8.2",
         "input-otp": "^1.2.0",
         "jszip": "^3.10.1",
         "lucide-react": "^0.487.0",
@@ -5600,6 +5601,12 @@
       "engines": {
         "node": "^12.20 || >= 14.13"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",

--- a/dataset_explorer/package.json
+++ b/dataset_explorer/package.json
@@ -50,6 +50,7 @@
     "cmdk": "^1.0.0",
     "date-fns": "^3.0.0",
     "embla-carousel-react": "^8.0.0",
+    "fflate": "^0.8.2",
     "input-otp": "^1.2.0",
     "jszip": "^3.10.1",
     "lucide-react": "^0.487.0",


### PR DESCRIPTION
This PR moves image upload logic away from supabase edge functions, due to memory limits for 40MB+ datasets. 
Structure: 
1. client-side unzipping using fflate
2. direct upload to supabase storage - done with concurrency of 24 
3. next.js endpoint for bulk insert into images table - done in batches of 2000 
4. Fixed optimistic update to only update with the first page

- Supabase edge function and related code will be removed in a future PR 
- Retry failed uploads will also be added in a future PR 

edge cases/ bugs
1. gets to end of 10000 images being uploaded to storage but doesn't call bulk insert sometimes?